### PR TITLE
Fix library install

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -4,9 +4,9 @@
 mkdir build && cd build
 cmake \
 	-DCMAKE_INSTALL_PREFIX=$PREFIX          \
+	-DCMAKE_INSTALL_LIBDIR=$PREFIX/lib      \
 	-DCMAKE_BUILD_TYPE=Release              \
 	-DFREEGLUT_BUILD_DEMOS=OFF              \
 	..
 make
 make install
-mv $PREFIX/lib64 $PREFIX/lib


### PR DESCRIPTION
Fix the library install directory to not have a `64` suffix.

This shouldn't change the final product. So am not bumping the build number.