### PR TITLE
NO MRG: TST: Re-render with a dev version of `conda-smithy` for CircleCI PR testing

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,10 @@
+checkout:
+  post:
+    # Checkout the merged PR for testing as CircleCI will just use the PR head otherwise.
+    - if [[ -n "${CIRCLE_PR_NUMBER}" ]]; then git fetch origin +refs/pull/$CIRCLE_PR_NUMBER/head:pr/$CIRCLE_PR_NUMBER/head ; fi
+    - if [[ -n "${CIRCLE_PR_NUMBER}" ]]; then git fetch origin +refs/pull/$CIRCLE_PR_NUMBER/merge:pr/$CIRCLE_PR_NUMBER/merge ; fi
+    - if [[ -n "${CIRCLE_PR_NUMBER}" ]]; then git checkout -qf pr/$CIRCLE_PR_NUMBER/merge ; fi
+
 machine:
   services:
     - docker


### PR DESCRIPTION
Re-renders with PR ( https://github.com/conda-forge/conda-smithy/pull/293 ), which checks out merge commits of PRs on CircleCI when testing a PR. This should make CircleCI behave in a more similar manner to that of other CIs.

cc @pelson