### PR TITLE
NO MRG: TST: Re-render with a dev version of `conda-smithy` for CircleCI PR testing

### DIFF
--- a/ci_support/checkout_merge_commit.sh
+++ b/ci_support/checkout_merge_commit.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+
+# Update PR refs for testing.
+if [[ -n "${CIRCLE_PR_NUMBER}" ]]
+then
+    FETCH_REFS="${FETCH_REFS} +refs/pull/${CIRCLE_PR_NUMBER}/head:pr/${CIRCLE_PR_NUMBER}/head"
+    FETCH_REFS="${FETCH_REFS} +refs/pull/${CIRCLE_PR_NUMBER}/merge:pr/${CIRCLE_PR_NUMBER}/merge"
+fi
+
+# Retrieve the refs.
+if [[ -n "${CIRCLE_PR_NUMBER}" ]]
+then
+    git fetch -u origin ${FETCH_REFS}
+fi
+
+# Checkout the PR merge ref.
+if [[ -n "${CIRCLE_PR_NUMBER}" ]]
+then
+    git checkout -qf "pr/${CIRCLE_PR_NUMBER}/merge"
+fi
+
+# Check for merge conflicts.
+if [[ -n "${CIRCLE_PR_NUMBER}" ]]
+then
+    git branch --merged | grep "pr/${CIRCLE_PR_NUMBER}/head" > /dev/null
+fi

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,7 @@
+checkout:
+  post:
+    - ./ci_support/checkout_merge_commit.sh
+
 machine:
   services:
     - docker


### PR DESCRIPTION
Please do **not** merge. This is for testing only.

Re-renders with PR ( https://github.com/conda-forge/conda-smithy/pull/309 ), which checks out merge commits of PRs on CircleCI when testing a PR. This should make CircleCI behave in a more similar manner to that of other CIs.

cc @pelson