### PR TITLE
Add regression test for CMake compilation and fix Windows

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -11,7 +11,7 @@ jobs:
       linux_64_:
         CONFIG: linux_64_
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: condaforge/linux-anvil-comp7
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
   timeoutInMinutes: 360
 
   steps:

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '7'
+- '9'
 cdt_name:
 - cos6
 channel_sources:
@@ -11,11 +11,13 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7'
+- '9'
 docker_image:
-- condaforge/linux-anvil-comp7
+- quay.io/condaforge/linux-anvil-comp7
 target_platform:
 - linux-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+- - cdt_name
+  - docker_image

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -3,7 +3,7 @@ BUILD:
 c_compiler:
 - gcc
 c_compiler_version:
-- '7'
+- '9'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -15,9 +15,9 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7'
+- '9'
 docker_image:
-- condaforge/linux-anvil-aarch64
+- quay.io/condaforge/linux-anvil-aarch64
 target_platform:
 - linux-aarch64
 zip_keys:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '8'
+- '9'
 cdt_name:
 - cos7
 channel_sources:
@@ -11,9 +11,9 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '8'
+- '9'
 docker_image:
-- condaforge/linux-anvil-ppc64le
+- quay.io/condaforge/linux-anvil-ppc64le
 target_platform:
 - linux-ppc64le
 zip_keys:

--- a/.drone.yml
+++ b/.drone.yml
@@ -8,7 +8,7 @@ platform:
 
 steps:
 - name: Install and build
-  image: condaforge/linux-anvil-aarch64
+  image: quay.io/condaforge/linux-anvil-aarch64
   environment:
     CONFIG: linux_aarch64_
     UPLOAD_PACKAGES: True

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @jakirkham @shadowwalkersb
+* @jakirkham @shadowwalkersb @wolfv

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -26,6 +26,14 @@ setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
 source run_conda_forge_build_setup
 
+
+# Install the yum requirements defined canonically in the
+# "recipe/yum_requirements.txt" file. After updating that file,
+# run "conda smithy rerender" and this line will be updated
+# automatically.
+/usr/bin/sudo -n yum install -y mesa-libGL mesa-dri-drivers libselinux libXdamage libXxf86vm libXext
+
+
 # make the build number clobber
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -45,8 +45,12 @@ fi
 if [ -z "${DOCKER_IMAGE}" ]; then
     SHYAML_INSTALLED="$(shyaml -h || echo NO)"
     if [ "${SHYAML_INSTALLED}" == "NO" ]; then
-        echo "WARNING: DOCKER_IMAGE variable not set and shyaml not installed. Falling back to condaforge/linux-anvil-comp7"
-        DOCKER_IMAGE="condaforge/linux-anvil-comp7"
+        echo "WARNING: DOCKER_IMAGE variable not set and shyaml not installed. Trying to parse with coreutils"
+        DOCKER_IMAGE=$(cat .ci_support/${CONFIG}.yaml | grep '^docker_image:$' -A 1 | tail -n 1 | cut -b 3-)
+        if [ "${DOCKER_IMAGE}" = "" ]; then
+            echo "No docker_image entry found in ${CONFIG}. Falling back to condaforge/linux-anvil-comp7"
+            DOCKER_IMAGE="condaforge/linux-anvil-comp7"
+        fi
     else
         DOCKER_IMAGE="$(cat "${FEEDSTOCK_ROOT}/.ci_support/${CONFIG}.yaml" | shyaml get-value docker_image.0 condaforge/linux-anvil-comp7 )"
     fi
@@ -64,8 +68,8 @@ fi
 
 export UPLOAD_PACKAGES="${UPLOAD_PACKAGES:-True}"
 docker run ${DOCKER_RUN_ARGS} \
-           -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw,z \
-           -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw,z \
+           -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw,z,delegated \
+           -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw,z,delegated \
            -e CONFIG \
            -e HOST_USER_ID \
            -e UPLOAD_PACKAGES \

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ language: generic
 
 matrix:
   include:
-    - env: CONFIG=linux_ppc64le_ UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=condaforge/linux-anvil-ppc64le
+    - env: CONFIG=linux_ppc64le_ UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=quay.io/condaforge/linux-anvil-ppc64le
       os: linux
       arch: ppc64le
 

--- a/README.md
+++ b/README.md
@@ -170,4 +170,5 @@ Feedstock Maintainers
 
 * [@jakirkham](https://github.com/jakirkham/)
 * [@shadowwalkersb](https://github.com/shadowwalkersb/)
+* [@wolfv](https://github.com/wolfv/)
 

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -6,8 +6,10 @@ cmake ^
 	-DCMAKE_INSTALL_LIBDIR=%LIBRARY_LIB%     ^
 	-DCMAKE_INSTALL_INCLUDEDIR=%LIBRARY_INC% ^
 	-DCMAKE_BUILD_TYPE=Release               ^
-	-DFREEGLUT_REPLACE_GLUT=ON              ^
+	-DFREEGLUT_REPLACE_GLUT=ON               ^
 	-DFREEGLUT_BUILD_DEMOS=OFF               ^
+	-DFREEGLUT_BUILD_STATIC_LIBS=OFF         ^
+	-DFREEGLUT_BUILD_SHARED_LIBS=ON          ^
 	..
 
 cmake --build . --config Release --target INSTALL

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,6 +50,7 @@ test:
     - {{ compiler('c') }}
     - cmake
     - ninja
+    - {{ cdt('mesa-libgl-devel') }}      # [linux]
 
   commands:
     # Test includes.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: d4000e02102acaf259998c870e25214739d1f16f67f99cb35e4f46841399da68
 
 build:
-  number: 0
+  number: 1
   skip: true  # [osx]
   run_exports:
     # https://abi-laboratory.pro/index.php?view=timeline&l=freeglut
@@ -60,11 +60,11 @@ test:
     - xorg-libxext                       # [linux]
     - xorg-libxfixes                     # [linux]
     - xorg-libxi                         # [linux]
-    - {{ cdt('mesa-dri-drivers') }}  # [linux]
-    - {{ cdt('libselinux') }}  # [linux]
-    - {{ cdt('libxdamage') }}  # [linux]
-    - {{ cdt('libxext') }}     # [linux]
-    - xorg-libxfixes  # [linux]
+    - {{ cdt('mesa-dri-drivers') }}      # [linux]
+    - {{ cdt('libselinux') }}            # [linux]
+    - {{ cdt('libxdamage') }}            # [linux]
+    - {{ cdt('libxext') }}               # [linux]
+    - xorg-libxfixes                     # [linux]
 
   commands:
     # Test includes.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -60,6 +60,11 @@ test:
     - xorg-libxext                       # [linux]
     - xorg-libxfixes                     # [linux]
     - xorg-libxi                         # [linux]
+    - {{ cdt('mesa-dri-drivers') }}  # [linux]
+    - {{ cdt('libselinux') }}  # [linux]
+    - {{ cdt('libxdamage') }}  # [linux]
+    - {{ cdt('libxext') }}     # [linux]
+    - xorg-libxfixes  # [linux]
 
   commands:
     # Test includes.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,6 +43,14 @@ requirements:
     - xorg-libxi                         # [linux]
 
 test:
+  files:
+    - test
+
+  requires:
+    - {{ compiler('c') }}
+    - cmake
+    - ninja
+
   commands:
     # Test includes.
     - test -d "${PREFIX}/include/GL"  # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,6 +51,8 @@ test:
     - cmake
     - ninja
     - {{ cdt('mesa-libgl-devel') }}      # [linux]
+    - {{ cdt('xorg-x11-proto-devel') }}  # [linux]
+    - {{ cdt('libxxf86vm-devel') }}      # [linux]
     - libglu                             # [linux]
 
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -54,6 +54,12 @@ test:
     - {{ cdt('xorg-x11-proto-devel') }}  # [linux]
     - {{ cdt('libxxf86vm-devel') }}      # [linux]
     - libglu                             # [linux]
+    - libxcb                             # [linux]
+    - xorg-libx11                        # [linux]
+    - xorg-libxau                        # [linux]
+    - xorg-libxext                       # [linux]
+    - xorg-libxfixes                     # [linux]
+    - xorg-libxi                         # [linux]
 
   commands:
     # Test includes.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,6 +51,7 @@ test:
     - cmake
     - ninja
     - {{ cdt('mesa-libgl-devel') }}      # [linux]
+    - libglu                             # [linux]
 
   commands:
     # Test includes.

--- a/recipe/run_test.bat
+++ b/recipe/run_test.bat
@@ -3,7 +3,7 @@ setlocal EnableDelayedExpansion
 cd test
 
 :: Compile and run example that links glut with CMake
-cmake -GNinja -DCMAKE_BUILD_TYPE=Release ..
+cmake -GNinja -DCMAKE_BUILD_TYPE=Release .
 if errorlevel 1 exit 1
 
 cmake --build . --config Release

--- a/recipe/run_test.bat
+++ b/recipe/run_test.bat
@@ -1,0 +1,13 @@
+setlocal EnableDelayedExpansion
+
+cd test
+
+:: Compile and run example that links glut with CMake
+cmake -GNinja -DCMAKE_BUILD_TYPE=Release ..
+if errorlevel 1 exit 1
+
+cmake --build . --config Release
+if errorlevel 1 exit 1
+
+.\test.exe 
+if errorlevel 1 exit 1

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -e
+
+# Test linking against glut with CMake
+cd test
+
+cmake -DCMAKE_BUILD_TYPE=Release .
+
+cmake --build . --config Release
+
+./test

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -3,7 +3,7 @@
 # Test linking against glut with CMake
 cd test
 
-cmake -DCMAKE_BUILD_TYPE=Release .
+cmake -GNinja -DCMAKE_BUILD_TYPE=Release .
 
 cmake --build . --config Release
 

--- a/recipe/test/CMakeLists.txt
+++ b/recipe/test/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.16)
+
+project(FreeGlutTest LANGUAGES C)
+
+find_package(GLUT REQUIRED)
+
+add_executable(test test.c)
+
+target_link_libraries(test PRIVATE GLUT::GLUT)

--- a/recipe/test/test.c
+++ b/recipe/test/test.c
@@ -1,0 +1,14 @@
+#include <GL/glut.h>
+
+int main()
+{
+    int glutIsInitialized = glutGet(GLUT_INIT_STATE);
+    
+    if (!glutIsInitialized) {
+        // This is the expected outcome
+        return 0;
+    } else {
+        // In this case something went wrong
+        return 1;
+    }
+}

--- a/recipe/test/test.c
+++ b/recipe/test/test.c
@@ -1,4 +1,6 @@
 #include <GL/glut.h>
+// For GLUT_INIT_STATE
+#include <GL/freeglut_ext.h>
 
 int main()
 {

--- a/recipe/yum_requirements.txt
+++ b/recipe/yum_requirements.txt
@@ -1,0 +1,6 @@
+mesa-libGL
+mesa-dri-drivers
+libselinux
+libXdamage
+libXxf86vm
+libXext


### PR DESCRIPTION
Disable compilation of static libraries on Windows to fix https://github.com/conda-forge/freeglut-feedstock/issues/26 .
Add CMake-based regression test to avoid regression such as  https://github.com/conda-forge/freeglut-feedstock/issues/26  in the future. 

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.