### PR TITLE
Disable autolink of freeglut.lib and fix use on Windows with CMake's Visual Studio generator

### DIFF
--- a/recipe/disable_autolink_windows.patch
+++ b/recipe/disable_autolink_windows.patch
@@ -1,0 +1,14 @@
+diff --git a/include/GL/freeglut_std.h b/include/GL/freeglut_std.h
+index a658c7c5..a8ea66c9 100644
+--- a/include/GL/freeglut_std.h
++++ b/include/GL/freeglut_std.h
+@@ -48,7 +48,7 @@
+  */
+ #   ifndef FREEGLUT_LIB_PRAGMAS
+ #       if ( defined(_MSC_VER) || defined(__WATCOMC__) ) && !defined(_WIN32_WCE)
+-#           define FREEGLUT_LIB_PRAGMAS 1
++#           define FREEGLUT_LIB_PRAGMAS 0
+ #       else
+ #           define FREEGLUT_LIB_PRAGMAS 0
+ #       endif
+ 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,9 +8,11 @@ source:
   fn: freeglut-{{ version }}.tar.bz2
   url: http://sourceforge.net/projects/freeglut/files/freeglut/{{ version }}/freeglut-{{ version }}.tar.gz
   sha256: d4000e02102acaf259998c870e25214739d1f16f67f99cb35e4f46841399da68
+  patches:
+    - disable_autolink_windows.patch
 
 build:
-  number: 1
+  number: 2
   skip: true  # [osx]
   run_exports:
     # https://abi-laboratory.pro/index.php?view=timeline&l=freeglut


### PR DESCRIPTION
Fix the second part of https://github.com/conda-forge/freeglut-feedstock/issues/26, the error `LINK : fatal error LNK1104: cannot open file 'freeglut.lib'` . Extended discussion in https://github.com/conda-forge/freeglut-feedstock/issues/26#issuecomment-769383551 . 

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.
