### PR TITLE
Do not export dependency on m library in .pc config on Windows

### DIFF
--- a/recipe/96.patch
+++ b/recipe/96.patch
@@ -1,0 +1,22 @@
+From 77d113e3b05e246fd12cba0640618c216abc06fb Mon Sep 17 00:00:00 2001
+From: Silvio Traversaro <silvio@traversaro.it>
+Date: Tue, 15 Feb 2022 14:42:46 +0100
+Subject: [PATCH] Do not link to libm on Windows
+
+---
+ freeglut/freeglut/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/freeglut/freeglut/CMakeLists.txt b/freeglut/freeglut/CMakeLists.txt
+index ac8c8df3..afdcfaea 100644
+--- a/freeglut/freeglut/CMakeLists.txt
++++ b/freeglut/freeglut/CMakeLists.txt
+@@ -581,7 +581,7 @@ ADD_DEMO(timer_callback  progs/demos/timer_callback/timer.c)
+ # pkg-config support, to install at $(libdir)/pkgconfig
+ # Define static build dependencies
+ IF(WIN32)
+-  SET(PC_LIBS_PRIVATE "-lopengl32 -lwinmm -lgdi32 -lm")
++  SET(PC_LIBS_PRIVATE "-lopengl32 -lwinmm -lgdi32")
+ ELSEIF(FREEGLUT_GLES)
+   IF(ANDROID)
+     SET(PC_LIBS_PRIVATE "-llog -landroid -lGLESv2 -lGLESv1_CM -lEGL -lm")

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,9 +10,10 @@ source:
   sha256: c5944a082df0bba96b5756dddb1f75d0cd72ce27b5395c6c1dde85c2ff297a50
   patches:
     - disable_autolink_windows.patch
+    - 96.patch
 
 build:
-  number: 0
+  number: 1
   skip: true  # [osx]
   run_exports:
     # https://abi-laboratory.pro/index.php?view=timeline&l=freeglut


### PR DESCRIPTION
If used in conjuction with CMake 3.23, on Windows trying to compile a target that links with GLUT::GLUT results in the error:
~~~
"C:\src\robotology-superbuild\build\src\ICUB\ALL_BUILD.vcxproj" (default target) (1) ->
"C:\src\robotology-superbuild\build\src\ICUB\src\tools\iCubGui\src\iCubGui.vcxproj" (default target) (53) ->
(Link target) ->
  LINK : fatal error LNK1181: cannot open input file 'm.lib' [C:\src\robotology-superbuild\build\src\ICUB\src\tools\iCubGui\src\iCubGui.vcxproj]

    6 Warning(s)
    1 Error(s)
~~~

This is because on Windows the `m` library does not exists. This PR fixes the problem by backporting the PR https://github.com/dcnieho/FreeGLUT/pull/96 .


Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
